### PR TITLE
Remove the hiding of entry titles from homepage

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,10 +211,6 @@ body.home #content {
     padding: 75px 15px;
 }
 
-body.home h1.entry-title {
-    display: none;
-}
-
 body.home .entry-content {
     margin-top: 0;
 }


### PR DESCRIPTION
I'm not fully satisfied with their display them, but seeing them is *def* better than just hiding them.